### PR TITLE
Fixed Transaction Id auto generation on unsuccessful request.

### DIFF
--- a/pkg/domain/account.go
+++ b/pkg/domain/account.go
@@ -18,7 +18,8 @@ type Account struct {
 
 type AccountRepository interface {
 	Save(Account) (*Account, *errs.AppError)
-	FindById(string) (*Account, *errs.AppError)
+	GetAccount(accountId string) (*Account, *errs.AppError)
+	FindById(accountId string, customerId string) (*Account, *errs.AppError)
 	SaveTransaction(Transaction) (*Transaction, *errs.AppError)
 }
 

--- a/pkg/service/accountService.go
+++ b/pkg/service/accountService.go
@@ -42,12 +42,15 @@ func (s DefaultAccountService) MakeTransaction(req dto.TransactionRequest) (*dto
 	if err != nil {
 		return nil, err
 	}
+
+	// fetching the account
+	account, err := s.repo.FindById(req.AccountId, req.CustomerId)
+	if err != nil {
+		return nil, errs.NewNotFoundError("Could not find account")
+	}
+
 	// server side validation for checking the available balance in the account
 	if req.IsTransactionTypeWithdrawal() {
-		account, err := s.repo.FindById(req.AccountId)
-		if err != nil {
-			return nil, err
-		}
 		if !account.CanWithdraw(req.Amount) {
 			return nil, errs.NewValidationError("Insufficient balance in the account")
 		}


### PR DESCRIPTION
Fixes #2 

* previously it was auto incrementing transaction Id even if last transaction was unsuccessful.
* Now Retrieving an account has two versions.
One is just fetch the account and other one will fetch account only if Account Id and Customer Id pair exists.